### PR TITLE
Ignore empty paragraph

### DIFF
--- a/src/textlint-rule-prefer-tari-tari.js
+++ b/src/textlint-rule-prefer-tari-tari.js
@@ -41,6 +41,10 @@ const report = context => {
                 const source = new StringSource(node);
                 const text = source.toString();
                 const CST = japaneseParser.parse(text);
+                // Ignore empty Paragraph. Ex) '<p></p>'
+                if (typeof CST.children === "undefined" || CST.children.length == 0) {
+                    return;
+                }
                 const sentences = CST.children[0].children;
                 const isSameNode = (resultsA, resultsB) => {
                     return resultsA.some(resultA => {
@@ -79,9 +83,12 @@ const report = context => {
                         // console.log(afterSuru.nodeList);
                         report(
                             node,
-                            new RuleError(`例示・並列・対表現において、片方の動詞が「〜たり」表現な場合は、もう片方の動詞も「〜たり」とします。`, {
-                                index: source.originalIndexFromIndex(afterSuru.position.index)
-                            })
+                            new RuleError(
+                                `例示・並列・対表現において、片方の動詞が「〜たり」表現な場合は、もう片方の動詞も「〜たり」とします。`,
+                                {
+                                    index: source.originalIndexFromIndex(afterSuru.position.index)
+                                }
+                            )
                         );
                     }
                 });

--- a/src/textlint-rule-prefer-tari-tari.js
+++ b/src/textlint-rule-prefer-tari-tari.js
@@ -83,12 +83,9 @@ const report = context => {
                         // console.log(afterSuru.nodeList);
                         report(
                             node,
-                            new RuleError(
-                                `例示・並列・対表現において、片方の動詞が「〜たり」表現な場合は、もう片方の動詞も「〜たり」とします。`,
-                                {
+                            new RuleError(`例示・並列・対表現において、片方の動詞が「〜たり」表現な場合は、もう片方の動詞も「〜たり」とします。`, {
                                     index: source.originalIndexFromIndex(afterSuru.position.index)
-                                }
-                            )
+                            })
                         );
                     }
                 });

--- a/src/textlint-rule-prefer-tari-tari.js
+++ b/src/textlint-rule-prefer-tari-tari.js
@@ -84,7 +84,7 @@ const report = context => {
                         report(
                             node,
                             new RuleError(`例示・並列・対表現において、片方の動詞が「〜たり」表現な場合は、もう片方の動詞も「〜たり」とします。`, {
-                                    index: source.originalIndexFromIndex(afterSuru.position.index)
+                                index: source.originalIndexFromIndex(afterSuru.position.index)
                             })
                         );
                     }


### PR DESCRIPTION
When applying `textlint-rule-prefer-tari-tari` to HTML, an error
occurred.

```console
✖ Stack trace
TypeError: Can not read property 'children' of undefined
    at
/usr/local/lib/node_modules/textlint-rule-prefer-tari-tari/lib/textlint-
rule-prefer-tari-tari.js:56:44
    at <anonymous>
    at process._ tickCallback (internal / process / next_tick.js: 188:
7)
```

I checked the contents of the NODE where the error occurred.

```console
### NODE
{type: 'Paragraph',
  tagName: 'p',
  properties: {},
  children: [],
  loc:
   {start: {line: 19, column: 12},
     end: {line: 19, column: 19}},
  range: [50138, 50145],
  raw: '<p> </ p>'}
### CST
{type: 'RootNode', children: [], position: {}}
### CST.children
[]
```

Fixed the program to ignore empty Paragraph like `<p> </ p>`.
