### PR TITLE
CI test: テストするNode.jsのバージョン修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14]
+        node-version: [18, 20, 22]
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
CI `test` でテストするNode.jsのバージョンを現在LTSやMaintananceなものに修正します。